### PR TITLE
[vbox] LZMA compression allows us to enable some more features

### DIFF
--- a/src/config/vbox/general.h
+++ b/src/config/vbox/general.h
@@ -1,25 +1,17 @@
 /* Disabled from config/defaults/pcbios.h */
 
-#undef IMAGE_ELF
 #undef SANBOOT_PROTO_ISCSI
 #undef SANBOOT_PROTO_AOE
 #undef SANBOOT_PROTO_IB_SRP
 #undef SANBOOT_PROTO_FCP
-#undef REBOOT_CMD
-#undef CPUID_CMD
 
 /* Disabled from config/general.h */
 
-#undef DOWNLOAD_PROTO_HTTP
 #undef CRYPTO_80211_WEP
 #undef CRYPTO_80211_WPA
 #undef CRYPTO_80211_WPA2
 #undef IWMGMT_CMD
-#undef FCMGMT_CMD
-#undef SANBOOT_CMD
 #undef MENU_CMD
-#undef LOGIN_CMD
-#undef SYNC_CMD
 
 /* Ensure ROM banner is not displayed */
 


### PR DESCRIPTION
Because of the improved LZMA compression, it is possible to enable some more features on the 56KB VirtualBox ROM build. It was decided that HTTP support was more important than menu support. None of the sanboot protocols could be improved, but the sanboot command is still usable to boot ISOs over HTTP.
